### PR TITLE
Add exception when not Mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ python_osc == 1.6.8
 qtaf == 5.4.30
 
 # osx_statusbar_app.py: 3,35
-rumps == 0.2.2
+rumps == 0.2.2; platform_system == "Darwin"
 
 # ServerBIT.py: 3
 # config_only.py: 3


### PR DESCRIPTION
rumps cannot be installed when using Linux. That is why I add an exception to install rumps requirement only on Mac 